### PR TITLE
Fix API-change handler and hide secrets

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -42,6 +42,8 @@ async def callback_router(update, context):
     elif data == "api_remove":
         del_api(user_id)
         await account_menu(update, context)
+    elif data == "api_change":
+        await api_entry_start(update, context)
     elif data == "reports_menu":
         await reports_menu(update, context)
     elif data == "remains_menu":

--- a/config.py
+++ b/config.py
@@ -1,2 +1,9 @@
-TELEGRAM_TOKEN = "7971708913:AAG6QBNsT2_iYPbewXBd7YQ99IsiZ6pcclU"
-LANDING_URL = "https://example.com"
+"""Configuration for the Telegram bot."""
+
+import os
+
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN")
+if not TELEGRAM_TOKEN:
+    raise RuntimeError("TELEGRAM_TOKEN environment variable not set")
+
+LANDING_URL = os.getenv("LANDING_URL", "https://example.com")

--- a/scenes/reports/remains.py
+++ b/scenes/reports/remains.py
@@ -2,6 +2,9 @@ from telegram import InlineKeyboardMarkup, InlineKeyboardButton, Update
 from telegram.ext import ContextTypes
 from user_storage import get_api
 from wb_api import get_stocks
+import logging
+
+logger = logging.getLogger(__name__)
 
 def remains_keyboard(page, total_pages):
     buttons = []
@@ -18,7 +21,7 @@ def remains_keyboard(page, total_pages):
 async def remains_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user_id = update.effective_user.id
     api_key = get_api(user_id)
-    print(f"[remains_menu] Отправляем API-ключ: >{api_key}<")  # Для отладки
+    logger.debug("[remains_menu] API key provided: %s", bool(api_key))
 
     # Определяем номер страницы из callback_data или берем 0 по умолчанию
     page = 0


### PR DESCRIPTION
## Summary
- read secrets from env variables
- enable `api_change` button in account scene
- replace debug print with logging

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840acdd7cd4832383151dfe63e799dd