### PR TITLE
Fix API edit callback

### DIFF
--- a/scenes/account.py
+++ b/scenes/account.py
@@ -12,7 +12,7 @@ def account_keyboard(api_set, balance, trial_active):
         if api_set:
             kb.append([
                 InlineKeyboardButton("📊 Отчёты", callback_data="reports_menu"),
-                InlineKeyboardButton("✏️ Изменить API-ключ", callback_data="api_change"),
+                InlineKeyboardButton("✏️ Изменить API-ключ", callback_data="api_entry"),
                 InlineKeyboardButton("❌ Удалить API", callback_data="api_remove"),
             ])
         else:


### PR DESCRIPTION
## Summary
- ensure 'Change API' button uses `api_entry` callback instead of `api_change`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6840b50117d883239a704b689cf6c2fc