### PR TITLE
Add callback query answer in remains menu

### DIFF
--- a/scenes/reports/remains.py
+++ b/scenes/reports/remains.py
@@ -16,6 +16,7 @@ def remains_keyboard(page, total_pages):
     return InlineKeyboardMarkup(buttons)
 
 async def remains_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    await update.callback_query.answer()
     user_id = update.effective_user.id
     api_key = get_api(user_id)
     print(f"[remains_menu] Отправляем API-ключ: >{api_key}<")  # Для отладки


### PR DESCRIPTION
## Summary
- prevent loading indicator from spinning by answering the callback query when opening remains menu

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_6840b525d8ec832387307b9ac22a5e4f