### PR TITLE
Remove print of API key and use logging

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -14,6 +14,10 @@ from scenes.reports.storage import storage_menu
 from scenes.reports.profit import profit_menu
 from user_storage import days_left, get_api, del_api, is_trial_active
 import config
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 async def callback_router(update, context):
     data = update.callback_query.data
@@ -73,7 +77,7 @@ def main():
     # 3. Потом общий CallbackQueryHandler для всех кнопок
     app.add_handler(CallbackQueryHandler(callback_router))
 
-    print("Бот запущен!")
+    logger.info("Бот запущен!")
     app.run_polling()
 
 if __name__ == "__main__":

--- a/scenes/reports/remains.py
+++ b/scenes/reports/remains.py
@@ -2,6 +2,9 @@ from telegram import InlineKeyboardMarkup, InlineKeyboardButton, Update
 from telegram.ext import ContextTypes
 from user_storage import get_api
 from wb_api import get_stocks
+import logging
+
+logger = logging.getLogger(__name__)
 
 def remains_keyboard(page, total_pages):
     buttons = []
@@ -18,7 +21,7 @@ def remains_keyboard(page, total_pages):
 async def remains_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     user_id = update.effective_user.id
     api_key = get_api(user_id)
-    print(f"[remains_menu] Отправляем API-ключ: >{api_key}<")  # Для отладки
+    logger.debug("[remains_menu] API key received and passed to request")
 
     # Определяем номер страницы из callback_data или берем 0 по умолчанию
     page = 0


### PR DESCRIPTION
## Summary
- use logging in `bot` and reports `remains` scene
- avoid printing sensitive API key

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6840b52f19fc8323865742fb372ec2d2