### PR TITLE
Fix remains report navigation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -46,6 +46,8 @@ async def callback_router(update, context):
         await reports_menu(update, context)
     elif data == "remains_menu":
         await remains_menu(update, context)
+    elif data.startswith("remains_page_"):
+        await remains_menu(update, context)
     elif data == "sales_menu":
         await sales_menu(update, context)
     elif data == "ads_menu":


### PR DESCRIPTION
## Summary
- route pagination callbacks for the remains report

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68420fc68d448323b0ca51682db6306c