### PR TITLE
Add sales menu callbacks

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -100,7 +100,7 @@ def main():
     app.add_handler(CallbackQueryHandler(admin_callback, pattern=r"^(admin_users|select_user:.*|ban:.*|unban:.*|add30:.*|main_menu)$"))
 
     # 4. CallbackQueryHandler для sales (отчёты по продажам)
-    app.add_handler(CallbackQueryHandler(sales_callback, pattern=r"^(sales_all|sales_articles|sales_articles_positive|sales_articles_all|sales_articles_page:.*|sales_article_select:.*|sales_period_.*|sales_date_select:.*|report:sales:.*)$"))
+    app.add_handler(CallbackQueryHandler(sales_callback, pattern=r"^(sales_menu|sales_main|sales_all|sales_articles|sales_articles_positive|sales_articles_all|sales_articles_page:.*|sales_article_select:.*|sales_period_.*|sales_date_select:.*|report:sales:.*)$"))
 
     # 5. CallbackQueryHandler для остальных callback (обычные кнопки)
     app.add_handler(CallbackQueryHandler(callback_router, pattern=r"^(start_btn|main_menu|pay_menu|pay_invoice|trial_activate|account_menu|api_remove|reports_menu|remains_menu|report:remains:.*|ads_menu|report:ads:.*|storage_menu|report:storage:.*|profit_menu|report:profit:.*)$"))


### PR DESCRIPTION
## Summary
- route `sales_menu` and `sales_main` callbacks to `sales_callback`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68492c2cf968832386bb70a2863334ba